### PR TITLE
update: build support on macos

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -125,7 +125,7 @@ pub fn save(envs: Vec<String>) {
     file.write_all(envs.join("\n").as_bytes()).unwrap();
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn gen_script(app_name: String) -> Result<String, String> {
     match std::env::var("SHELL") {
         Ok(shell) => {


### PR DESCRIPTION
## Summary
This PR adds support for building the project on macOS using Cargo.
Confirmation was performed only on Macos Ventura.
Therefore, it is necessary to verify whether it can be built properly on Linux.

I've never touched rust before, so I'm proposing this change while looking through the documentation.
So, even though it's a very small change, please check it carefully to see if there are any problems.

## Changes
Modified the conditional compilation attributes to include macOS as a target OS alongside Linux.
